### PR TITLE
tidy up dependencies and build config

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   `kotlin-dsl`
 }
@@ -16,28 +14,6 @@ dependencies {
   implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 
-val gradleJvmTarget = "11"
-val gradleJvmVersion = "11"
-
-tasks.withType<KotlinCompile>().configureEach {
-
-  kotlinOptions {
-    jvmTarget = gradleJvmTarget
-  }
-
-  kotlinOptions.freeCompilerArgs += listOf(
-    "-opt-in=kotlin.RequiresOptIn",
-    "-opt-in=kotlin.ExperimentalStdlibApi",
-    "-opt-in=kotlin.time.ExperimentalTime",
-  )
-}
-
 kotlin {
-  jvmToolchain {
-    languageVersion.set(JavaLanguageVersion.of(gradleJvmVersion))
-  }
-
-  kotlinDslPluginOptions {
-    jvmTarget.set(gradleJvmTarget)
-  }
+  jvmToolchain(11)
 }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -1,5 +1,7 @@
 package buildsrc.convention
 
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_5
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 
@@ -7,63 +9,38 @@ plugins {
   id("buildsrc.convention.base")
   kotlin("jvm")
   `java-library`
-  // id("org.jetbrains.dokka")
 }
-
-
-dependencies {
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
-    because("Only needed to run tests in a version of IntelliJ IDEA that bundles older versions")
-  }
-
-  testImplementation("io.kotest:kotest-runner-junit5")
-  testImplementation("io.kotest:kotest-assertions-core")
-  testImplementation("io.kotest:kotest-property")
-  testImplementation("io.kotest:kotest-assertions-json")
-
-  testImplementation("io.mockk:mockk")
-}
-
 
 kotlin {
-  jvmToolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
+  jvmToolchain(11)
 }
-
 
 tasks.withType<KotlinCompile>().configureEach {
 
-  kotlinOptions {
-    apiVersion = "1.5"
-    languageVersion = "1.8"
+  compilerOptions {
+    apiVersion.set(KOTLIN_1_5)
+    languageVersion.set(KOTLIN_1_8)
+
+    freeCompilerArgs.addAll(
+      "-opt-in=kotlin.ExperimentalStdlibApi",
+      "-opt-in=kotlin.time.ExperimentalTime",
+    )
   }
-
-  kotlinOptions.freeCompilerArgs += listOf(
-    "-opt-in=kotlin.RequiresOptIn",
-    "-opt-in=kotlin.ExperimentalStdlibApi",
-    "-opt-in=kotlin.time.ExperimentalTime",
-  )
 }
-
 
 tasks.compileTestKotlin {
-  kotlinOptions.freeCompilerArgs += "-opt-in=io.kotest.common.ExperimentalKotest"
+  compilerOptions {
+    freeCompilerArgs.addAll(
+      "-opt-in=io.kotest.common.ExperimentalKotest"
+    )
+  }
 }
-
 
 tasks.withType<Test>().configureEach {
   useJUnitPlatform()
 }
 
-
 java {
   withJavadocJar()
   withSourcesJar()
-}
-
-
-tasks.withType<Jar>().named("javadocJar") {
-//  from(tasks.dokkaHtml)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,8 @@ kotlinxSerialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serial
 kotlinxSerialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor" }
 kotlinxSerialization-properties = { module = "org.jetbrains.kotlinx:kotlinx-serialization-properties" }
 
-slf4jApi = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
 ## Dokka
 kotlin-dokkaPlugin-allModulesPage = { module = "org.jetbrains.dokka:all-modules-page-plugin", version.ref = "kotlin-dokka" }
@@ -94,10 +95,10 @@ gradlePlugin-kotlinxSerialization = { module = "org.jetbrains.kotlin:kotlin-seri
 #########
 
 kotest = [
-  "kotest-assertionsCore",
-  "kotest-assertionsJson",
-  "kotest-property",
-  "kotest-frameworkEngine",
-  "kotest-frameworkDatatest",
-  "kotest-runnerJUnit5",
+    "kotest-assertionsCore",
+    "kotest-assertionsJson",
+    "kotest-property",
+    "kotest-frameworkEngine",
+    "kotest-frameworkDatatest",
+    "kotest-runnerJUnit5",
 ]

--- a/modules/kotka-streams-extensions/build.gradle.kts
+++ b/modules/kotka-streams-extensions/build.gradle.kts
@@ -11,6 +11,13 @@ dependencies {
   implementation(platform(projects.modules.versionsPlatform))
 
   implementation(libs.kafka.streams)
+
+  testImplementation(libs.kotest.runnerJUnit5)
+  testImplementation(libs.kotest.assertionsCore)
+  testImplementation(libs.kotest.property)
+  testImplementation(libs.kotest.assertionsJson)
+
+  testImplementation(libs.mockk)
 }
 
 

--- a/modules/kotka-streams-framework/build.gradle.kts
+++ b/modules/kotka-streams-framework/build.gradle.kts
@@ -13,6 +13,13 @@ dependencies {
   api(projects.modules.kotkaStreamsExtensions)
 
   implementation(libs.kafka.streams)
+
+  testImplementation(libs.kotest.runnerJUnit5)
+  testImplementation(libs.kotest.assertionsCore)
+  testImplementation(libs.kotest.property)
+  testImplementation(libs.kotest.assertionsJson)
+
+  testImplementation(libs.mockk)
 }
 
 

--- a/modules/kotka-streams-kotlinx-serialization/build.gradle.kts
+++ b/modules/kotka-streams-kotlinx-serialization/build.gradle.kts
@@ -16,12 +16,21 @@ dependencies {
 
   implementation(libs.kafka.streams)
 
-  implementation(libs.slf4jApi)
+  implementation(libs.slf4j.api)
 
   implementation(libs.kotlinxSerialization.core)
 
+  testImplementation(libs.kotest.runnerJUnit5)
+  testImplementation(libs.kotest.assertionsCore)
+  testImplementation(libs.kotest.property)
+  testImplementation(libs.kotest.assertionsJson)
+
+  testImplementation(libs.mockk)
+
   testImplementation(libs.kotlinxSerialization.cbor)
   testImplementation(libs.kotlinxSerialization.json)
+
+  testImplementation(libs.slf4j.simple)
 }
 
 

--- a/modules/versions-platform/build.gradle.kts
+++ b/modules/versions-platform/build.gradle.kts
@@ -7,11 +7,9 @@ plugins {
 
 description = "Aligns versions of project dependencies"
 
-
 javaPlatform {
   allowDependencies()
 }
-
 
 dependencies {
   api(platform(libs.kotlin.bom))
@@ -24,6 +22,8 @@ dependencies {
     api(libs.kafka.streams)
     api(libs.kotlinx.knitTest)
     api(libs.mockk)
+    api(libs.slf4j.api)
+    api(libs.slf4j.simple)
   }
 }
 


### PR DESCRIPTION
- remove test dependencies from convention plugins to make things more declarative
- add slf4j simple to test dependencies to stifle warning
- add slf4j dependencies to version-platform
- tidy up some build config after the Gradle 8 Kotlin 1.8 bump