### PR TITLE
re-add github-environment

### DIFF
--- a/.github/workflows/run_gradle_task.yml
+++ b/.github/workflows/run_gradle_task.yml
@@ -18,6 +18,14 @@ on:
         description: "The repository reference to checkout"
         required: false
         type: string
+      github-environment:
+        description: "GitHub Environment name"
+        required: false
+        type: string
+      github-environment-url:
+        description: "GitHub Environment display URL"
+        required: false
+        type: string
   workflow_call:
     inputs:
       gradle-task:
@@ -30,6 +38,14 @@ on:
         type: string
       checkout-ref:
         description: "The repository reference to checkout"
+        required: false
+        type: string
+      github-environment:
+        description: "GitHub Environment name"
+        required: false
+        type: string
+      github-environment-url:
+        description: "GitHub Environment display URL"
         required: false
         type: string
 
@@ -51,6 +67,9 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: "./gradlew ${{ inputs.gradle-task}} @ ${{ inputs.runs-on }}"
     timeout-minutes: 60
+    environment:
+      name: ${{ inputs.github-environment }}
+      url: ${{ inputs.github-environment-url }}
     steps:
 
       ### Gradle task ###

--- a/.github/workflows/run_gradle_task.yml
+++ b/.github/workflows/run_gradle_task.yml
@@ -98,6 +98,8 @@ jobs:
           "ORG_GRADLE_PROJECT_signing.password": ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeRepositoryUsername: ${{ secrets.SONATYPE_REPO_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypeRepositoryPassword: ${{ secrets.SONATYPE_REPO_PASSWORD }}
+          ORG_GRADLE_PROJECT_gitHubPackagesRepositoryUsername: ${{ env.USERNAME }}
+          ORG_GRADLE_PROJECT_gitHubPackagesRepositoryPassword: ${{ env.TOKEN }}
 
       - name: Upload build reports
         if: failure()

--- a/.github/workflows/run_publish_maven.yml
+++ b/.github/workflows/run_publish_maven.yml
@@ -42,6 +42,8 @@ jobs:
         --stacktrace
         --no-configuration-cache
         --no-parallel
+      github-environment: sonatype-publish
+      github-environment-url: https://s01.oss.sonatype.org/
       checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
 
 

--- a/buildSrc/src/main/kotlin/buildsrc/ext/KotkaPublishingSettings.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/ext/KotkaPublishingSettings.kt
@@ -24,7 +24,7 @@ abstract class KotkaPublishingSettings @Inject constructor(
   )
 
   val gitHubPackagesCredentials: Provider<Action<PasswordCredentials>> =
-    providers.credentialsAction("GitHubPackages")
+    providers.credentialsAction("gitHubPackages")
 
   val sonatypeRepositoryCredentials: Provider<Action<PasswordCredentials>> =
     providers.credentialsAction("sonatypeRepository")


### PR DESCRIPTION
GitHub Environment 'sonatype-publish' contains the secrets. 

This config was removed in #38 but needs to be re-added so that the secrets are available.