### PR TITLE
gh package publishing, secrets: inherit

### DIFF
--- a/.github/workflows/run_publish_maven.yml
+++ b/.github/workflows/run_publish_maven.yml
@@ -53,6 +53,7 @@ jobs:
       packages: write
       checks: write
     uses: ./.github/workflows/run_gradle_task.yml
+    secrets: inherit
     with:
       runs-on: ubuntu-latest
       gradle-task: >-


### PR DESCRIPTION
Try to fix [error](https://github.com/adamko-dev/kotka-streams/actions/runs/7294617491/job/19879848031)

```
Caused by: org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException: Could not GET 'https://maven.pkg.github.com/adamko-dev/kotka-streams/dev/adamko/kotka/kotka-streams/main-SNAPSHOT/maven-metadata.xml'. Received status code 401 from server: Unauthorized
```