### PR TITLE
GHA fix checkout-ref

### DIFF
--- a/.github/workflows/run_gradle_task.yml
+++ b/.github/workflows/run_gradle_task.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.checkout-ref || github.ref }}
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/run_publish_maven.yml
+++ b/.github/workflows/run_publish_maven.yml
@@ -1,5 +1,6 @@
 name: Publish Maven
 
+
 on:
   workflow_dispatch:
     inputs:
@@ -44,7 +45,7 @@ jobs:
         --no-parallel
       github-environment: sonatype-publish
       github-environment-url: https://s01.oss.sonatype.org/
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}
 
 
   github-packages-release:
@@ -60,4 +61,4 @@ jobs:
         --stacktrace
         --no-configuration-cache
         --no-parallel
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}

--- a/.github/workflows/run_publish_site.yml
+++ b/.github/workflows/run_publish_site.yml
@@ -1,5 +1,6 @@
 name: Publish Site
 
+
 on:
   workflow_dispatch:
     inputs:
@@ -28,7 +29,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.checkout-ref || github.ref }}
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,8 +1,10 @@
 name: Tests
 
+
 on:
   workflow_dispatch:
   workflow_call:
+
 
 concurrency:
   group: "Tests: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/.github/workflows/workflow_pull_request.yml
+++ b/.github/workflows/workflow_pull_request.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "renovate/**"
 
+
 concurrency:
   group: "Pull Requests: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true

--- a/.github/workflows/workflow_release.yml
+++ b/.github/workflows/workflow_release.yml
@@ -37,7 +37,7 @@ jobs:
       contents: write
       packages: write
     with:
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}
 
   publish-site:
     needs: tests
@@ -51,4 +51,4 @@ jobs:
       packages: write
       pages: write      # to deploy to Pages
     with:
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}


### PR DESCRIPTION
 - don't fall back to the main branch! Use the ref of the event that triggered the action (`github.ref`)